### PR TITLE
Fix navigation after file dialog cancellation

### DIFF
--- a/src/ios/FileChooser.swift
+++ b/src/ios/FileChooser.swift
@@ -67,6 +67,6 @@ extension FileChooser : UIDocumentPickerDelegate {
 	}
 
 	func documentPickerWasCancelled (_ controller: UIDocumentPickerViewController) {
-		self.send("RESULT_CANCELED")
+		self.sendError("RESULT_CANCELED")
 	}
 }


### PR DESCRIPTION
If you start attaching a file but then close the dialog, we weren't navigating back to where the user was e.g. in a task drillthrough page. I found that sending the cancel message with an error code fixed this (we probably catch errors somewhere and reopen the window).