### PR TITLE
Encapsulating selection data from other local data

### DIFF
--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -22,12 +22,20 @@ module.exports = {
 
             // file must be copied to local folder to be accessible by app..
             const localFolder = Windows.Storage.ApplicationData.current.localFolder;
-            file.copyAsync(localFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
-            .done(function (savedFile) {
-                successCallback('ms-appdata:///local/' + savedFile.name);
-            }, function(err) {
+
+            // Path to unique folder for uploads within local folder. Encapsulate file selection/upload data from other local data
+            const appUploadFolder = "cordova-filechooser-plugin\\windows\\uploads\\";
+
+            localFolder.createFolderAsync(appUploadFolder, Windows.Storage.CreationCollisionOption.OpenIfExists).done(function (uploadsFolder) {
+                file.copyAsync(uploadsFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
+                    .done(function (savedFile) {
+                        successCallback('ms-appdata:///local/cordova-filechooser-plugin/windows/uploads/' + savedFile.name);
+                    }, function (err) {
+                        errorCallback(pickerErrorMessage);
+                    });
+            }, function (err) {
                 errorCallback(pickerErrorMessage);
-            });
+            } )
         }, function () {
             errorCallback(pickerErrorMessage);
         });

--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -24,12 +24,12 @@ module.exports = {
             const localFolder = Windows.Storage.ApplicationData.current.localFolder;
 
             // Path to unique folder for uploads within local folder. Encapsulate file selection/upload data from other local data
-            const appUploadFolder = "cordova-filechooser-plugin\\windows\\uploads\\";
+            const appUploadFolder = "cordova-filechooser-plugin\\uploads\\";
 
             localFolder.createFolderAsync(appUploadFolder, Windows.Storage.CreationCollisionOption.openIfExists).done(function (uploadsFolder) {
                 file.copyAsync(uploadsFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
                     .done(function (savedFile) {
-                        successCallback('ms-appdata:///local/cordova-filechooser-plugin/windows/uploads/' + savedFile.name);
+                        successCallback('ms-appdata:///local/cordova-filechooser-plugin/uploads/' + savedFile.name);
                     }, function (err) {
                         errorCallback(pickerErrorMessage);
                     });

--- a/src/windows/FileChooserProxy.js
+++ b/src/windows/FileChooserProxy.js
@@ -26,7 +26,7 @@ module.exports = {
             // Path to unique folder for uploads within local folder. Encapsulate file selection/upload data from other local data
             const appUploadFolder = "cordova-filechooser-plugin\\windows\\uploads\\";
 
-            localFolder.createFolderAsync(appUploadFolder, Windows.Storage.CreationCollisionOption.OpenIfExists).done(function (uploadsFolder) {
+            localFolder.createFolderAsync(appUploadFolder, Windows.Storage.CreationCollisionOption.openIfExists).done(function (uploadsFolder) {
                 file.copyAsync(uploadsFolder, file.name, Windows.Storage.NameCollisionOption.replaceExisting)
                     .done(function (savedFile) {
                         successCallback('ms-appdata:///local/cordova-filechooser-plugin/windows/uploads/' + savedFile.name);


### PR DESCRIPTION
For the file chooser plugin, the windows implementation copies the selected file to the local directory (ms-appdata:///local/). The reason for this is to allow this file to be accessible by the app (see src/windows/FileChooserProxy.js#L23)  

If the local directory is shared with other functionality, there is a chance that files could be accidentally overridden  when picking files (among other things). For instance, a function could generate a file called `generated1.png` and store it in the local directory. Another function could allow uploading files, of which if the file uploaded has the same name (generated1.png), it will overwrite that previous file.  

Other errors could also be incurred as in the case of preprocessing uploaded files. I.e name of the processed output could conflict with a previously uploaded file 